### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/UniversalStandards/New-Government-agency-banking-Program/security/code-scanning/2](https://github.com/UniversalStandards/New-Government-agency-banking-Program/security/code-scanning/2)

To fix this problem, the workflow should explicitly specify the minimal required permissions. In this case, the workflow only needs to read the repository contents (to check out code and run tests/lint). Therefore, a `permissions` block granting `contents: read` should be added. This should be placed at the top level (root) of the workflow, which applies it to all jobs unless a job-level `permissions` block overrides it. 

Specifically:
- Edit `.github/workflows/python-package.yml`
- Add the following block immediately after the `name: Python package` line (after line 4), and before `on:`
- No changes to any imports or any other structural pieces are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
